### PR TITLE
Fix problems with keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,4 +1,4 @@
 FaderOSC	KEYWORD1
-useUDP		KEYWORD2
+useUDP	KEYWORD2
 useSerial	KEYWORD2
 iteration	KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -1,4 +1,4 @@
 FaderOSC	KEYWORD1
 useUDP		KEYWORD2
-useSerial	KEYWORD3
-iteration	KEYWORD4
+useSerial	KEYWORD2
+iteration	KEYWORD2


### PR DESCRIPTION
- Use valid and correct KEYWORD_TOKENTYPEs.
- Use a single tab field separator.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords